### PR TITLE
회원 로그인 실패 오류 해결

### DIFF
--- a/src/sql/user/user_login.sql
+++ b/src/sql/user/user_login.sql
@@ -20,4 +20,4 @@ DELIMITER ;
 
 SET @output_member_id = NULL;
 CALL LoginUser('user1', 'user1', @output_member_id);
-SELECT @output_member_id, name  from member m where m.member_id = @output_member_id ;
+SELECT @output_member_id;


### PR DESCRIPTION
#5 
- admin 로그인 로직에서 각자 로그인/비번만 다른건데 왜 회원은 output_id에 따라서 where 조건절이 먹히지 않는 것인지 모르겠음
- select로 아웃풋 id만 반환하도록 수정하면 set 한 대로 잘 반환됨 





